### PR TITLE
Don't kill MySQL in single controller HA mode (Bug: 1425719)

### DIFF
--- a/deployment/puppet/osnailyfacter/modular/astute/set_mysql_fail_action.rb
+++ b/deployment/puppet/osnailyfacter/modular/astute/set_mysql_fail_action.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'hiera'
+require 'timeout'
+
+RETRY_COUNT   = 5
+RETRY_WAIT    = 1
+RETRY_TIMEOUT = 10
+
+def get_nodes
+  hiera = Hiera.new(:config => '/etc/puppet/hiera.yaml')
+  nodes_array = hiera.lookup 'nodes', [], {}
+  raise 'Invalid nodes data!' unless nodes_array.is_a? Array
+  nodes_array
+end
+
+def get_controller_nodes
+  get_nodes.select {|n|
+    ['controller', 'primary-controller'].include? n['role']
+  }.size
+end
+
+def set_onfail_policy(operation_id, value)
+  puts "Setting on-fail for op id '#{operation_id}' to: '#{value}'"
+  RETRY_COUNT.times do |n|
+    begin
+      Timeout::timeout(RETRY_TIMEOUT) do
+        system "cibadmin -M -X '<op id=\"#{operation_id}\" on-fail=\"#{value}\" />"
+        return if $?.exitstatus == 0
+      end
+    rescue Timeout::Error
+      nil
+    end
+    puts "Error! Retry: #{n + 1}"
+    sleep RETRY_WAIT
+  end
+  fail "Could not set on-fail for op id '#{operation_id}' to: '#{value}'!"
+end
+
+def get_onfail_policy(operation_id)
+  RETRY_COUNT.times do |n|
+    begin
+      Timeout::timeout(RETRY_TIMEOUT) do
+        value = 'undefined'
+        raw = `cibadmin -QA '//op[@id="#{operation_id}"]'`.chomp
+        raw.split(' ').each do |part|
+          if part =~ /^on-fail=/
+            value = part.split('=')[1].gsub(/["']/, '')
+          end
+        end
+        return value if $?.exitstatus == 0
+      end
+    rescue Timeout::Error
+      nil
+    end
+    puts "Error! Retry: #{n + 1}"
+    sleep RETRY_WAIT
+  end
+  fail "Could not get on-fail for op id '#{operation_id}!"
+end
+
+##############
+
+opid = 'p_mysql-monitor-60'
+
+controller_nodes = get_controller_nodes
+current_onfail_policy = get_onfail_policy(opid)
+
+puts "Controller nodes found: '#{controller_nodes}'"
+
+if controller_nodes > 2
+  set_onfail_policy(opid, 'restart') unless current_onfail_policy(opid) == 'restart'
+else
+  set_onfail_policy(opid, 'ignore') unless current_onfail_policy(opid) == 'ignore'
+end
+
+puts "Current on-fail policy for op #{opid} is: '#{get_onfail_policy(opid)}'"
+exit 0

--- a/deployment/puppet/osnailyfacter/modular/astute/tasks.yaml
+++ b/deployment/puppet/osnailyfacter/modular/astute/tasks.yaml
@@ -6,6 +6,14 @@
     cmd: ruby /etc/puppet/modules/osnailyfacter/modular/astute/enable_quorum.rb
     timeout: 180
 
+- id: set_mysql_fail_action
+  type: shell
+  role: [primary-controller]
+  stage: post_deployment
+  parameters:
+    cmd: ruby /etc/puppet/modules/osnailyfacter/modular/astute/set_mysql_fail_action.rb
+    timeout: 180
+
 - id: restart_rados
   type: shell
   role: [primary-controller, controller]


### PR DESCRIPTION
Added post-deployment task, and related script to allow ignoring of mysql-monitor output by corosync so it won't attempt to kill it in the event that it's the only controller in the cluster.
